### PR TITLE
Sync users instead of roles into LDAP groups

### DIFF
--- a/app/Console/Commands/MoveGroupRolesFromLdapToDatabase.php
+++ b/app/Console/Commands/MoveGroupRolesFromLdapToDatabase.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Ldap\Community;
+use App\Ldap\Group;
+use App\Models\GroupMembership;
+use Illuminate\Console\Command;
+
+class MoveGroupRolesFromLdapToDatabase extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:move-group-roles-from-ldap-to-database
+                {community? : The short name to search for of the community}
+                {group? : The short name to search for of the group}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $realms = Community::query()
+            ->list() // only first level
+            ->setDn(Community::$rootDn)
+            ->search('ou', $this->argument('community'))
+            ->get();
+
+        foreach ($realms as $realm) {
+            $groups = Group::fromCommunity($realm->getFirstAttribute('ou'))
+                ->search('ou', $this->argument('group'))
+                ->get();
+
+            foreach ($groups as $group) {
+                $this->comment("> " . $group->getDn());
+
+                // get roles
+                $roles = $group->members()->get();
+
+                foreach ($roles as $role) {
+                    $this->comment($role);
+                    GroupMembership::create([
+                        'group_dn' => $group->getDn(),
+                        'role_dn' => $role,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/app/Livewire/Group/AddRoleToGroup.php
+++ b/app/Livewire/Group/AddRoleToGroup.php
@@ -9,6 +9,8 @@ use App\Ldap\Role;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
 
+use App\Models\GroupMembership;
+
 class AddRoleToGroup extends Component
 {
     #[Locked]
@@ -42,9 +44,12 @@ class AddRoleToGroup extends Component
 
     public function save()
     {
-        /** @var Group $group */
-        $group = Group::findOrFail(Group::dnFrom($this->uid, $this->group_cn));
-        $group->members()->attach($this->selected_role_dn);
+        $group_dn = Group::findOrFail(Group::dnFrom($this->uid, $this->group_cn));
+        GroupMembership::create([
+            'group_dn' => $group_dn,
+            'role_dn' => $this->selected_role_dn,
+        ]);
+
         return redirect()->route('realms.groups.roles', ['uid' => $this->uid, 'cn' => $this->group_cn])
             ->with('message', __('groups.success_role_add'))
         ;

--- a/app/Models/GroupMembership.php
+++ b/app/Models/GroupMembership.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property integer $group_id
+ * @property Group $group
+ * @property Role $role
+ */
+
+class GroupMembership extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'role_group_relation';
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'group_dn',
+        'role_dn',
+    ];
+
+    public function roles(): HasMany
+    {
+        return $this->hasMany(Role::class);
+    }
+}

--- a/database/migrations/2025_06_27_095320_create_role_group_relation.php
+++ b/database/migrations/2025_06_27_095320_create_role_group_relation.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_group_relation', function (Blueprint $table) {
+            $table->id();
+            $table->string('group_dn');
+            $table->string('role_dn');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_group_relation');
+    }
+};


### PR DESCRIPTION
This is necessary for the possibility to connect other SSO applications like Keycloak to the LDAP an successfully sync the groups the users belong to.